### PR TITLE
update osrm urls, use 6 digits for decoding geometry

### DIFF
--- a/app/assets/javascripts/app/config.js.coffee.erb
+++ b/app/assets/javascripts/app/config.js.coffee.erb
@@ -66,8 +66,9 @@ IBikeCPH.config =
 		value: new L.LatLngBounds(new L.LatLng(55.885903, 12.019043), new L.LatLng(55.489553, 12.989209)) # Max bounds of the map
 
 	routing_service:
-		standard: 'http://routes.ibikecph.dk/standard/viaroute'
-		cargobike: 'http://routes.ibikecph.dk/cargobike/viaroute'
+		standard: 'http://routes.ibikecph.dk/v1.1/fast/viaroute'
+		cargobike: 'http://routes.ibikecph.dk/v1.1/cargo/viaroute'
+		greenbike: 'http://routes.ibikecph.dk/v1.1/green/viaroute'
 
 	geocoding_service:
 		url: 'http://nominatim.openstreetmap.org/search'

--- a/app/assets/javascripts/app/util.js.coffee
+++ b/app/assets/javascripts/app/util.js.coffee
@@ -112,7 +112,7 @@ IBikeCPH.util.decode_path = (encoded) ->
 
 		lng += dlng
 
-		points.push new L.LatLng(lat * 1e-5, lng * 1e-5)
+		points.push new L.LatLng(lat * 1e-6, lng * 1e-6)
 
 	return points
 


### PR DESCRIPTION
updates urls to point to the new v1.1 version of the osrm routing service, and uses 6 digits instead of 5 for decoding the geometry.
