### PR TITLE
Formatted foursquare version number correctly. It should probably sti…

### DIFF
--- a/app/assets/javascripts/app/config.js.coffee.erb
+++ b/app/assets/javascripts/app/config.js.coffee.erb
@@ -89,7 +89,7 @@ IBikeCPH.config =
 	suggestion_service:
 		foursquare:
 			url: 'https://api.foursquare.com/v2/venues/suggestcompletion?near=Copenhagen&query='
-			token: '&oauth_token=BM2LGKP3TZURURN3R0NFYGQPQH3PU3L2WDNRF1MUJPSKYV1N&v=201303'
+			token: '&oauth_token=BM2LGKP3TZURURN3R0NFYGQPQH3PU3L2WDNRF1MUJPSKYV1N&v=20130303' # version number should probably be updated, but this still works
 		oiorest:
 			url: 'http://geo.oiorest.dk/adresser.json?q='
 		kms:


### PR DESCRIPTION
Foursquare wasn't being used for suggestions because the version number string wasn't in the correct format. It needed to be in a `YYYYMMDD` format.