### PR TITLE
compute duration in front-end based on average speed

### DIFF
--- a/app/assets/javascripts/app/config.js.coffee.erb
+++ b/app/assets/javascripts/app/config.js.coffee.erb
@@ -75,9 +75,15 @@ IBikeCPH.config =
     base_url: 'https://routes.ibikecph.dk'
     precision: 1e-5
     profiles:
-      fast: 'v5/fast/route'
-      cargo: 'v5/cargo/route'
-      green: 'v5/green/route'
+      fast:
+        url: 'v5/fast/route'
+        speed: 15
+      cargo:
+        url: 'v5/cargo/route'
+        speed: 10
+      green:
+        url: 'v5/green/route'
+        speed: 15
 
   geocoding_service:
     url: 'https://nominatim.openstreetmap.org/search'

--- a/app/assets/javascripts/app/config.js.coffee.erb
+++ b/app/assets/javascripts/app/config.js.coffee.erb
@@ -75,9 +75,9 @@ IBikeCPH.config =
     base_url: 'https://routes.ibikecph.dk'
     precision: 1e-5
     profiles:
-      fast: 'v5/fast'
-      cargo: 'v5/cargo'
-      green: 'v5/green'
+      fast: 'v5/fast/route'
+      cargo: 'v5/cargo/route'
+      green: 'v5/green/route'
 
   geocoding_service:
     url: 'https://nominatim.openstreetmap.org/search'

--- a/app/assets/javascripts/consumers/OSRM.js.coffee
+++ b/app/assets/javascripts/consumers/OSRM.js.coffee
@@ -62,12 +62,26 @@ class IBikeCPH.OSRM
       #  @hints[locations[index]] = hint
     
       @model.set 'route', route.geometry
-      @model.summary.set { total_distance: route.distance, total_time: route.duration, summary: route.summary } 
+      @model.summary.set { total_distance: route.distance, total_duration: @compute_duration(route.distance), summary: route.summary }
       @model.instructions.reset_from_osrm route
+
+  compute_duration: (meters) ->
+      # Instead of using the duration provided by OSRM, we compute it as distance/speed.
+      # The reason is that OSRM cannot yet work with speed and weight separated, which
+      # means we have to use unrealistic speeds for prioritize e.g. green routes.
+      # This causes the duration to be incorrect.
+      # The workaround is not without problems, however: If the route includes large sections
+      # where the bike must be pushed, the duration will be too optimistic. It also
+      # means turns and traffic lights are not taken into account.
+
+      profile = @model.get('profile') or @model.standard_profile()
+      average_speed = IBikeCPH.config.routing_service.profiles[ profile ].speed
+      seconds = 3.6 * meters / average_speed  # convert from km/h to m/s
+      return seconds
 
   build_request: (profile, locations) ->
     base_url = IBikeCPH.config.routing_service.base_url
-    profile_str = IBikeCPH.config.routing_service.profiles[ profile ]
+    profile_str = IBikeCPH.config.routing_service.profiles[ profile ].url
     
     locations_str = locations.join(';')
     

--- a/app/assets/javascripts/views/summary.js.coffee
+++ b/app/assets/javascripts/views/summary.js.coffee
@@ -23,7 +23,7 @@ class IBikeCPH.Views.Summary extends Backbone.View
   
   render: =>
     meters = @model.get 'total_distance'
-    seconds  = @model.get 'total_time'  
+    seconds = @model.get 'total_duration'
     if meters and seconds
       @abort_hide()
       @$el.show()

--- a/app/lib/travel_planner.rb
+++ b/app/lib/travel_planner.rb
@@ -13,7 +13,10 @@ module TravelPlanner
     opt[:date] = now.strftime("%d.%m.%Y")
     opt[:time] = now.strftime("%H:%M")
     journey = TravelPlanner::Journey.new(opt)
-    journey.trips
+    {
+      code:'Ok',
+      routes: journey.routes
+    }
   end
 
   def self.options(loc)

--- a/app/lib/travel_planner/coord_set.rb
+++ b/app/lib/travel_planner/coord_set.rb
@@ -37,6 +37,10 @@ class TravelPlanner::CoordSet
     [ coords[0].to_s+','+coords[1].to_s, coords[2].to_s+','+coords[3].to_s ]
   end
 
+  def for_osrm
+    coords[1].to_s + ',' + coords[0].to_s + ';' + coords[3].to_s + ',' + coords[2].to_s
+  end
+
   def for_polyline
     poly_coords = coords.map {|coord| coord.to_f}
     [[poly_coords[0],poly_coords[1]], [poly_coords[2],poly_coords[3]]]

--- a/app/lib/travel_planner/leg.rb
+++ b/app/lib/travel_planner/leg.rb
@@ -31,7 +31,7 @@ class TravelPlanner::Leg
   def parse_time(station)
     # No timezone is supplied by Rejseplanen, thus we assume Copenhagen.
     offset_in_seconds = TZInfo::Timezone.get('Europe/Copenhagen').current_period.utc_total_offset
-    offset_in_hours = (2*offset_in_seconds / 3600).ceil.to_s
+    offset_in_hours = (offset_in_seconds / 3600).ceil.to_s
     format = '%d.%m.%y%H:%M%z'
 
     Time.strptime(station['date'] + station['time'] + '+0' + offset_in_hours, format).to_i

--- a/app/lib/travel_planner/leg.rb
+++ b/app/lib/travel_planner/leg.rb
@@ -83,7 +83,7 @@ class TravelPlanner::Leg
         maneuver: {
             type: :depart
         },
-        mode:     :train,
+        mode:     :idling,
         duration: duration,
         name:     origin['name'],
         distance: distance,
@@ -92,7 +92,7 @@ class TravelPlanner::Leg
         maneuver: {
             type: :arrive
         },
-        mode:     :train,
+        mode:     :idling,
         duration: 0,
         name:     destination['name'],
         distance: 0,

--- a/app/lib/travel_planner/leg.rb
+++ b/app/lib/travel_planner/leg.rb
@@ -30,12 +30,11 @@ class TravelPlanner::Leg
   private
   def parse_time(station)
     # No timezone is supplied by Rejseplanen, thus we assume Copenhagen.
-    # This returns either CET or CEST, depending on if it's summer time.
-    zone = TZInfo::Timezone.get('Europe/Copenhagen').current_period.offset.abbreviation.to_s
+    offset_in_seconds = TZInfo::Timezone.get('Europe/Copenhagen').current_period.utc_total_offset
+    offset_in_hours = (2*offset_in_seconds / 3600).ceil.to_s
+    format = '%d.%m.%y%H:%M%z'
 
-    format = '%d.%m.%y%H:%M%Z'
-
-    Time.strptime(station['date'] + station['time'] + zone, format).to_i
+    Time.strptime(station['date'] + station['time'] + '+0' + offset_in_hours, format).to_i
   end
 
   def extract_coords(global_coords)

--- a/app/lib/travel_planner/leg.rb
+++ b/app/lib/travel_planner/leg.rb
@@ -29,9 +29,13 @@ class TravelPlanner::Leg
 
   private
   def parse_time(station)
-    format = '%d.%m.%y %H:%M %Z'
-    s = station['date'] + ' ' + station['time'] + ' Copenhagen'
-    Time.strptime(s, format).to_i
+    # No timezone is supplied by Rejseplanen, thus we assume Copenhagen.
+    # This returns either CET or CEST, depending on if it's summer time.
+    zone = TZInfo::Timezone.get('Europe/Copenhagen').current_period.offset.abbreviation.to_s
+
+    format = '%d.%m.%y%H:%M%Z'
+
+    Time.strptime(station['date'] + station['time'] + zone, format).to_i
   end
 
   def extract_coords(global_coords)

--- a/spec/api/v1/journeys_spec.rb
+++ b/spec/api/v1/journeys_spec.rb
@@ -33,7 +33,7 @@ describe 'Journey API', api: :v1 do
       json = JSON.parse(response.body)
       expect(response.status).to eq(422)
       expect(json.length).to eq 1
-      expect(json["error"]).to eq("not ready")  
+      expect(json["error"]).to eq("not ready")
 
       # poll using invalid token should return 404, "not found"
       get "/api/journeys/99999999999", {}, headers
@@ -48,9 +48,11 @@ describe 'Journey API', api: :v1 do
       get "/api/journeys/#{CGI.escape token}", {}, headers
       json = JSON.parse(response.body)
       expect(response.status).to eq(200)
-      expect(json.length).to eq 3
-      expect(json[0]).to have_key('journey')
-      expect(json[0]).to have_key('journey_summary')
+      expect(json).to have_key('routes')
+      expect(json['routes'].length).to eq 3
+      expect(json['routes'][0]).to have_key('distance')
+      expect(json['routes'][0]['distance']).to be > 0
+      expect(json['routes'][0]).to have_key('legs')
     end
   end
 end


### PR DESCRIPTION
Compute travel times as distance / speed_contant, instead of using the travel times provides by OSRM. the reason for doing this is that OSRM currently provides broken travel times for green routes. for consistency, we compute travel times manually for all route types.

it's a workaround, and as such doesn't take into account traffic lights, pushing the bike, etc.

cc @sphinxominator: this fix is already deployed on production, but is not in the develop or master branch here on github. if you deploy other commits, please make sure this PR is merged and deployed.
