### PR TITLE
Better check for empty postalCode

### DIFF
--- a/app/assets/javascripts/views/sidebar.js.coffee
+++ b/app/assets/javascripts/views/sidebar.js.coffee
@@ -217,7 +217,7 @@ class IBikeCPH.Views.Sidebar extends Backbone.View
       $.getJSON foursquare_url, (data) ->
         if data.response.minivenues and data.response.minivenues.length>0
           $.each data.response.minivenues, ->
-            unless @location.postalCode is ""
+            if @location.lat? and @location.lng? and @location.address? and @location.postalCode?
               items.push
                 name: @name
                 address: @location.address + ", " + @location.postalCode + " " + @location.city


### PR DESCRIPTION
If Foursquare returns a hit without a postal address, the suggestion dropdown shows “undefined, undefined, undefined“.

![image](https://user-images.githubusercontent.com/111346/28501561-a2e48426-6fde-11e7-8c37-f78695647baa.png)

It seems that if a venue has no postal code, the postalCode key does not appear in the JSON response. I could not find any occurrences of postalCode being an empty string, so it seems Foursquare has changed their API since the current check was added.