### PR TITLE
Move to a faster polylines decoder

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -33,7 +33,7 @@ gem 'koala'
 gem 'httparty'
 gem "rack-timeout", require:"rack/timeout/base"
 gem 'redcarpet'
-gem 'polylines'
+gem 'fast-polylines'
 
 group :development, :test do
   gem 'dotenv-rails', :require => 'dotenv/rails-now'    # make sure this loads early

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -120,6 +120,7 @@ GEM
       railties (>= 3.0.0)
     faraday (0.12.2)
       multipart-post (>= 1.2, < 3)
+    fast-polylines (1.0.0)
     ffi (1.9.25)
     figaro (1.1.1)
       thor (~> 0.14)
@@ -211,7 +212,6 @@ GEM
     platform-api (2.1.0)
       heroics (~> 0.0.23)
       moneta (~> 0.8.1)
-    polylines (0.3.0)
     public_suffix (3.0.2)
     puma (3.11.4)
     rack (2.0.5)
@@ -329,6 +329,7 @@ DEPENDENCIES
   eco
   exception_notification
   factory_bot_rails
+  fast-polylines
   figaro
   fog-aws
   httparty
@@ -341,7 +342,6 @@ DEPENDENCIES
   omniauth
   omniauth-facebook
   pg (~> 0.20)
-  polylines
   puma
   rack-timeout
   rails

--- a/app/lib/travel_planner/leg.rb
+++ b/app/lib/travel_planner/leg.rb
@@ -69,12 +69,12 @@ class TravelPlanner::Leg
       end
     end
 
-    Polylines::Encoder.encode_points(coords)
+    FastPolylines::Encoder.encode(coords)
   end
 
   def destination_coord_geometry
     poly_coords = coords.for_polyline
-    Polylines::Encoder.encode_points([poly_coords[1]])
+    FastPolylines::Encoder.encode([poly_coords[1]])
   end
 
   def build_steps


### PR DESCRIPTION
Moving to a 10x faster gem to decode polylines in OSRM processors (see [README](https://github.com/klaxit/fast-polylines/blob/master/README.md) for the benchmark).

**Disclaimer**: I am the author of this gem @klaxit. We have been using this gem in production to decode 1M+ polylines a day for more than 6 months.